### PR TITLE
Update DEVSETUP.md

### DIFF
--- a/DEVSETUP.md
+++ b/DEVSETUP.md
@@ -3,11 +3,9 @@
 1. install nodejs (nodejs) (nvm for mac and linux)
 2. Verify git is install by opening up the command line and running the following command `git --version`. If you get a message saying 'command not found', then install git on you computer by following the instructions here: [Install Git](knowthen.com/gitinstall)
 3. [CD](<https://en.wikipedia.org/wiki/Cd_(command)>) into a directory you'd like to put your code in, then clone the courses companion repo with the following command
-
 ```
-git clone git@github.com:knowthen/fpjs.git
+git clone https://github.com/knowthen/fpjs.git
 ```
-
 ## Using the counter directory
 
 4. CD into the new `fpjs/counter` folder.


### PR DESCRIPTION
change git clone method from using ssh to https (easier for newbies to  cope with).

ssh method used fails if no ssh key is added to github. As this is surely the case for most new people to github, https seems to be a better clone method to avoid cloning errors.